### PR TITLE
Fixed the transaction delete callback

### DIFF
--- a/js/gitana/Transaction.js
+++ b/js/gitana/Transaction.js
@@ -102,7 +102,7 @@
         }
         else
         {
-            transaction.getDriver().gitanaDelete('/transactions/' + transaction.getId(), {}, {}, function(res) {
+            transaction.getDriver().gitanaDelete('/transactions/' + transaction.getId(), {}, function(res) {
                 def.resolve(res);
             }, function(err) {
                 def.reject(err);


### PR DESCRIPTION
Looks like the delete call for canceling transactions has an extra `{}` in the parameter list causing it to error.